### PR TITLE
set noDelay to true on IRC sockets

### DIFF
--- a/src/irc/server.js
+++ b/src/irc/server.js
@@ -112,6 +112,7 @@ export default class Server {
 			});
 		}
 
+		socket.setNoDelay(true);
 		socket.setEncoding(this.info.encoding);
 		socket.on('data', this._onSocketData.bind(this));
 		socket.on('connect', this._onSocketConnected.bind(this));


### PR DESCRIPTION
by default, sockets in Node.js use Nagle's algorithm, which can cause small packets to be buffered for a short time, increasing latency: https://en.wikipedia.org/wiki/Nagle%27s_algorithm

we can use `socket.setNoDelay(true)` to bypass the default behavior: https://devdocs.io/node/net#net_socket_setnodelay_nodelay